### PR TITLE
feat: live API status in tray tooltip + settings header

### DIFF
--- a/app/tray/settings_window.py
+++ b/app/tray/settings_window.py
@@ -114,10 +114,20 @@ class SettingsWindow:
         win = tk.Tk()
         self._win = win
         win.title("stt-trans Einstellungen")
-        win.geometry("620x770")
+        win.geometry("620x800")
         win.configure(bg=BG)
         win.resizable(False, False)
         win.protocol("WM_DELETE_WINDOW", self._close)
+
+        # ── Status-Header (Live API + Recording) ─────────────────────────
+        status_bar = tk.Frame(win, bg=CARD)
+        status_bar.pack(fill="x", padx=0, pady=(0, 4))
+        self._status_lbl = tk.Label(
+            status_bar, text="API: …", bg=CARD, fg=MUTED,
+            font=(FONT, 9), anchor="w", padx=12, pady=4,
+        )
+        self._status_lbl.pack(side="left", fill="x", expand=True)
+        self._poll_api_status()  # initial + repeat alle 3s
 
         style = ttk.Style(win)
         style.theme_use("clam")
@@ -702,6 +712,33 @@ class SettingsWindow:
             self._win = None
         if self.on_close:
             self.on_close()
+
+    def _poll_api_status(self) -> None:
+        """Aktualisiert Status-Header im UI-Thread, alle 3s."""
+        if not self._win or not getattr(self, "_status_lbl", None):
+            return
+        try:
+            health = self.client.get_health()
+            status = self.client.get_status()
+            cfg = self.client.get_config()
+            rec = status.get("recording", False)
+            mode = status.get("mode") or "—"
+            txt = (
+                f"API ✓ {health.get('status','?')}  •  "
+                f"Provider: {cfg.get('llm_provider','?')}  •  "
+                f"Modell: {cfg.get('llm_model','?')}  •  "
+                f"Whisper: {cfg.get('local_whisper_model','?')}  •  "
+                f"Recording: {'● ' + mode if rec else 'idle'}"
+            )
+            color = "#22c55e" if not rec else BLUE
+        except Exception as e:
+            txt = f"API ✗ offline ({type(e).__name__})"
+            color = "#ef4444"
+        try:
+            self._status_lbl.configure(text=txt, fg=color)
+        except Exception:
+            return
+        self._win.after(3000, self._poll_api_status)
 
 
 def _format_key_display(key_name: str, device_name: str) -> str:

--- a/app/tray/tray_app.py
+++ b/app/tray/tray_app.py
@@ -59,7 +59,7 @@ class BlitztextTrayApp:
         t.start()
 
     def _poll_status(self) -> None:
-        """Pollt /api/status alle 3s und wechselt Icon."""
+        """Pollt /api/status alle 3s, wechselt Icon und aktualisiert Tooltip."""
         import time
         _idle_icon = create_tray_icon(64)
         _rec_icon = create_recording_icon(64)
@@ -69,15 +69,27 @@ class BlitztextTrayApp:
             time.sleep(3)
             if self._icon is None:
                 break
+            api_ok = True
+            is_rec = False
+            mode = None
             try:
                 status = self.client.get_status()
                 is_rec = status.get("recording", False)
+                mode = status.get("mode")
             except Exception:
-                is_rec = False
+                api_ok = False
 
             if is_rec != _was_recording:
                 _was_recording = is_rec
                 self._icon.icon = _rec_icon if is_rec else _idle_icon
+
+            if api_ok:
+                self._icon.title = (
+                    f"stt-trans | API ✓ | recording: {mode}"
+                    if is_rec else "stt-trans | API ✓ | idle"
+                )
+            else:
+                self._icon.title = "stt-trans | API ✗ offline"
 
     def _quit(self, icon=None, item=None) -> None:
         if self._icon:


### PR DESCRIPTION
## Summary
- Tray icon tooltip shows API health + recording state, refreshed every 3s
- Settings window has live status bar at the top: API health, provider, LLM model, Whisper model, recording state
- Color codes: green idle / blue recording / red offline
- Window grown 770→800 to fit the new bar

## Test plan
- [ ] Hover tray icon → tooltip shows "API ✓ idle"
- [ ] Press F8 → tooltip switches to "recording: plus" within 3s
- [ ] Open settings → status bar visible at top with current config
- [ ] Stop daemon (`systemctl --user stop stt-trans.service`) → tooltip + bar turn red within 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)