### PR TITLE
fix: Live-Modus reconnectet + claude_cli-Cleanup von globaler CLAUDE.md isoliert

### DIFF
--- a/app/daemon.py
+++ b/app/daemon.py
@@ -54,49 +54,72 @@ class BlitztextDaemon:
                     best_has_key_name = True
         return best_mode
 
-    async def _toggle_live(self) -> None:
-        """Startet oder stoppt den Live-Transkriptions-Modus."""
-        if self._session is not None:
-            logger.warning("PTT läuft — Live-Modus nicht gestartet")
-            return
-
-        # Stop-Button im Browser könnte live._live_mic_session geleert haben
+    def _sync_live_state(self) -> None:
+        """Browser-Stop könnte live._live_mic_session geleert haben — Daemon nachziehen."""
         if self._live_mic_session is not None and live._live_mic_session is None:
             self._live_mic_session = None
             self._live_desktop_session = None
 
+    def _open_live_page(self) -> None:
+        try:
+            subprocess.Popen(
+                ["xdg-open", "http://localhost:8765/live"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except FileNotFoundError:
+            logger.warning("xdg-open nicht gefunden — öffne http://localhost:8765/live manuell")
+
+    async def _start_live(self) -> bool:
+        """Startet Live-Sessions, falls nicht bereits aktiv. True = neu gestartet."""
+        if self._session is not None:
+            logger.warning("PTT läuft — Live-Modus nicht gestartet")
+            return False
+        self._sync_live_state()
+        if self._live_mic_session is not None:
+            return False  # läuft bereits
+        loop = asyncio.get_running_loop()
+        monitor = find_monitor_device()
+        audio_device = self.cfg.audio_device if self.cfg.audio_device != "default" else "pulse"
+        mic = LiveRecordingSession(device=audio_device)
+        desktop = LiveRecordingSession(device=monitor) if monitor else None
+        mic.start(loop)
+        if desktop:
+            desktop.start(loop)
+        self._live_mic_session = mic
+        self._live_desktop_session = desktop
+        live.set_sessions(mic, desktop)
+        live.set_stop_callback(self._on_live_stopped)
+        asyncio.create_task(live.start_pumps())
+        notify("recording", "Live-Transkription gestartet")
+        self._open_live_page()
+        return True
+
+    async def _stop_live(self) -> None:
+        """Stoppt aktive Live-Sessions (idempotent)."""
+        self._sync_live_state()
         if self._live_mic_session is None:
-            loop = asyncio.get_running_loop()
-            monitor = find_monitor_device()
-            audio_device = self.cfg.audio_device if self.cfg.audio_device != "default" else "pulse"
-            mic = LiveRecordingSession(device=audio_device)
-            desktop = LiveRecordingSession(device=monitor) if monitor else None
-            mic.start(loop)
-            if desktop:
-                desktop.start(loop)
-            self._live_mic_session = mic
-            self._live_desktop_session = desktop
-            live.set_sessions(mic, desktop)
-            live.set_stop_callback(self._on_live_stopped)
-            asyncio.create_task(live.start_pumps())
-            notify("recording", "Live-Transkription gestartet")
-            try:
-                subprocess.Popen(
-                    ["xdg-open", "http://localhost:8765/live"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-            except FileNotFoundError:
-                logger.warning("xdg-open nicht gefunden — öffne http://localhost:8765/live manuell")
+            return
+        self._live_mic_session.stop()
+        self._live_mic_session = None
+        if self._live_desktop_session:
+            self._live_desktop_session.stop()
+            self._live_desktop_session = None
+        live.set_sessions(None, None)
+        live.set_stop_callback(None)
+        notify("done", "Live-Transkription beendet")
+
+    async def _toggle_live(self) -> None:
+        """Hotkey-Verhalten: startet oder stoppt den Live-Modus."""
+        self._sync_live_state()
+        if self._live_mic_session is None:
+            await self._start_live()
         else:
-            self._live_mic_session.stop()
-            self._live_mic_session = None
-            if self._live_desktop_session:
-                self._live_desktop_session.stop()
-                self._live_desktop_session = None
-            live.set_sessions(None, None)
-            live.set_stop_callback(None)
-            notify("done", "Live-Transkription beendet")
+            await self._stop_live()
+
+    async def start_live(self) -> bool:
+        """Öffentlicher Einstieg für die HTTP-/Tray-Steuerung (idempotenter Start)."""
+        return await self._start_live()
 
     async def _run_pipeline(self, mode_name: str, wav_bytes: bytes) -> None:
         """Whisper → LLM → inject."""

--- a/app/process.py
+++ b/app/process.py
@@ -40,19 +40,38 @@ def get_client() -> AsyncOpenAI:
     return _client
 
 
+def _strip_meta_lines(text: str) -> str:
+    """Entfernt 🔊-TTS-Zeilen, falls die CLI doch Begleittext erzeugt (Defense-in-Depth)."""
+    lines = [ln for ln in text.splitlines() if not ln.lstrip().startswith("🔊")]
+    return "\n".join(lines).strip()
+
+
 async def _call_claude_cli(system_prompt: str, text: str, model: str) -> str:
-    """Pipe text into the local Claude CLI (uses Max-Plan login, no API key)."""
-    proc = await asyncio.create_subprocess_exec(
-        "claude", "-p", "--model", model or "haiku",
-        "--output-format", "text", system_prompt,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await proc.communicate(input=text.encode())
+    """Pipe text into the local Claude CLI (uses Max-Plan login, no API key).
+
+    --setting-sources "" verhindert das Laden von ~/.claude/CLAUDE.md, Hooks,
+    Auto-Memory und Projekt-Settings — sonst erbt der Cleanup-Aufruf die
+    persoenliche Agent-Persoenlichkeit (z.B. supertonic-🔊-Zeile, Meta-Kommentare).
+    Die Anweisung gehoert in --system-prompt, der Transkript-Text ist der User-Prompt.
+    cwd ist ein neutrales Temp-Verzeichnis (keine projekt-lokale CLAUDE.md).
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory(prefix="blitztext-claude-") as tmpdir:
+        proc = await asyncio.create_subprocess_exec(
+            "claude", "-p", text,
+            "--model", model or "haiku",
+            "--system-prompt", system_prompt,
+            "--setting-sources", "",
+            "--output-format", "text",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=tmpdir,
+        )
+        stdout, stderr = await proc.communicate()
     if proc.returncode != 0:
         raise RuntimeError(f"claude CLI failed (exit {proc.returncode}): {stderr.decode()[:200]}")
-    return stdout.decode().strip()
+    return _strip_meta_lines(stdout.decode())
 
 
 _EMOJI_COUNT_MAP = {

--- a/app/routes/live.py
+++ b/app/routes/live.py
@@ -202,6 +202,17 @@ async def live_page() -> FileResponse:
     return FileResponse(_STATIC_DIR / "live.html")
 
 
+@router.post("/live/start")
+async def start_live_route() -> dict:
+    """Startet den Live-Modus (idempotent) — für Tray-/UI-Steuerung."""
+    from app.main import get_daemon
+    daemon = get_daemon()
+    if daemon is None:
+        return {"ok": False, "error": "Daemon nicht bereit"}
+    started = await daemon.start_live()
+    return {"ok": True, "started": started}
+
+
 @router.post("/live/stop")
 async def stop_live() -> dict:
     """Stoppt beide Live-Sessions vom Browser aus."""

--- a/app/routes/status_routes.py
+++ b/app/routes/status_routes.py
@@ -13,4 +13,5 @@ def get_status():
     return {
         "recording": daemon._active_mode is not None,
         "mode": daemon._active_mode,
+        "live": daemon._live_mic_session is not None,
     }

--- a/app/static/live.html
+++ b/app/static/live.html
@@ -61,6 +61,11 @@
            font-size:12px;font-weight:600;background:#ef4444;color:#fff;">
     ⏹ Stop
   </button>
+  <button id="reconnect-btn" onclick="reconnectNow()"
+    style="padding:5px 14px;border-radius:6px;border:none;cursor:pointer;
+           font-size:12px;font-weight:600;background:#3b82f6;color:#fff;">
+    🔄 Neu verbinden
+  </button>
   <span id="clock"></span>
 </div>
 
@@ -102,7 +107,8 @@ const WS_BASE = `ws://${location.host}`;
 let micWs = null, desktopWs = null;
 let micMuted = false;
 let firstMicChunk = true, firstDesktopChunk = true;
-let stopped = false;
+let pageClosing = false;
+window.addEventListener('beforeunload', () => { pageClosing = true; });
 
 // Clock
 setInterval(() => {
@@ -124,11 +130,18 @@ function setLang(stream, lang) {
 }
 
 function stopLive() {
-  stopped = true;
+  // Stoppt nur die Backend-Session; die Seite bleibt offen und wartet
+  // auf eine neue Session (Reconnect-Loop läuft weiter).
+  fetch('/live/stop', { method: 'POST' }).catch(() => {});
   if (micWs) micWs.close();
   if (desktopWs) desktopWs.close();
-  fetch('/live/stop', { method: 'POST' });
-  updateStatus(false);
+}
+
+function reconnectNow() {
+  if (micWs) { try { micWs.close(); } catch (e) {} }
+  if (desktopWs) { try { desktopWs.close(); } catch (e) {} }
+  connectWs('mic');
+  connectWs('desktop');
 }
 
 function toggleMic() {
@@ -173,7 +186,7 @@ function updateStatus(connected) {
     text.textContent = '🔴 Live';
   } else {
     dot.className = '';
-    text.textContent = 'Verbindung getrennt…';
+    text.textContent = '⏳ Warte auf Live-Session…';
   }
 }
 
@@ -194,7 +207,7 @@ function connectWs(stream) {
 
   ws.onmessage = (e) => {
     const data = JSON.parse(e.data);
-    if (data.done) { stopped = true; return; }
+    if (data.done) return;
     if (data.error) return;  // no session yet — onclose handles retry
     if (!data.text) return;
     appendChunk(`${stream}-transcript`, data);
@@ -203,7 +216,7 @@ function connectWs(stream) {
   ws.onclose = () => {
     dot.className = 'ws-dot';
     updateStatus(false);
-    if (!stopped) setTimeout(() => connectWs(stream), 3000);
+    if (!pageClosing) setTimeout(() => connectWs(stream), 3000);
   };
 
   ws.onerror = () => ws.close();

--- a/app/tray/api_client.py
+++ b/app/tray/api_client.py
@@ -33,6 +33,16 @@ class BlitztextClient:
         r.raise_for_status()
         return r.json()
 
+    def start_live(self) -> dict[str, Any]:
+        r = requests.post(f"{self.base}/live/start", timeout=5)
+        r.raise_for_status()
+        return r.json()
+
+    def stop_live(self) -> dict[str, Any]:
+        r = requests.post(f"{self.base}/live/stop", timeout=5)
+        r.raise_for_status()
+        return r.json()
+
     def list_input_devices(self) -> list[tuple[str, str]]:
         """Returns list of (path, name) tuples for all evdev devices."""
         devices: list[tuple[str, str]] = []

--- a/app/tray/tray_app.py
+++ b/app/tray/tray_app.py
@@ -10,6 +10,7 @@ if "PYSTRAY_BACKEND" not in os.environ:
         pass
 
 import pystray
+from app.inject import notify
 from app.tray.api_client import BlitztextClient
 from app.tray.icon import create_tray_icon, create_recording_icon
 from app.tray.settings_window import SettingsWindow
@@ -25,6 +26,8 @@ class BlitztextTrayApp:
         icon_image = create_tray_icon(64)
         menu = pystray.Menu(
             pystray.MenuItem("Einstellungen öffnen", self._open_settings, default=True),
+            pystray.MenuItem("Live-Modus starten", self._start_live),
+            pystray.MenuItem("Live-Modus stoppen", self._stop_live),
             pystray.MenuItem("Neustart", self._restart_daemon),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem("Beenden", self._quit),
@@ -33,14 +36,34 @@ class BlitztextTrayApp:
         threading.Thread(target=self._poll_status, daemon=True).start()
         self._icon.run()
 
+    def _start_live(self, icon=None, item=None) -> None:
+        try:
+            self.client.start_live()
+            notify("recording", "Live-Modus gestartet")
+        except Exception as e:
+            notify("error", f"Live-Start fehlgeschlagen: {e}")
+
+    def _stop_live(self, icon=None, item=None) -> None:
+        try:
+            self.client.stop_live()
+            notify("done", "Live-Modus gestoppt")
+        except Exception as e:
+            notify("error", f"Live-Stop fehlgeschlagen: {e}")
+
     def _restart_daemon(self, icon=None, item=None) -> None:
-        """Restart the stt-trans systemd user service."""
+        """Restart the stt-trans systemd user service (mit Feedback)."""
         import subprocess
-        subprocess.run(
-            ["systemctl", "--user", "restart", "stt-trans.service"],
-            capture_output=True,
-            timeout=15,
-        )
+        try:
+            r = subprocess.run(
+                ["systemctl", "--user", "restart", "stt-trans.service"],
+                capture_output=True, timeout=15, text=True,
+            )
+            if r.returncode == 0:
+                notify("done", "stt-trans neu gestartet")
+            else:
+                notify("error", f"Neustart fehlgeschlagen ({r.returncode})")
+        except Exception as e:
+            notify("error", f"Neustart-Fehler: {e}")
 
     def _open_settings(self, icon=None, item=None) -> None:
         # tkinter mainloop muss in eigenem Thread laufen (pystray blockiert main thread)

--- a/tests/test_live_routes.py
+++ b/tests/test_live_routes.py
@@ -23,6 +23,21 @@ def test_broadcast_delivers_to_all_subscribers():
         loop.close()
 
 
+def test_start_live_route_calls_daemon():
+    """start_live_route() ruft daemon.start_live() auf und gibt das Ergebnis zurueck."""
+    from app.routes.live import start_live_route
+    loop = asyncio.new_event_loop()
+    try:
+        mock_daemon = MagicMock()
+        mock_daemon.start_live = AsyncMock(return_value=True)
+        with patch("app.main.get_daemon", return_value=mock_daemon):
+            result = loop.run_until_complete(start_live_route())
+        assert result == {"ok": True, "started": True}
+        mock_daemon.start_live.assert_awaited_once()
+    finally:
+        loop.close()
+
+
 def test_set_sessions_stores_sessions():
     """set_sessions() speichert Sessions im Modul-State."""
     mock_mic = MagicMock()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,7 +1,7 @@
 # tests/test_process.py
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from app.process import process_text, ProcessMode
+from app.process import process_text, ProcessMode, _strip_meta_lines, _call_claude_cli
 
 @pytest.mark.asyncio
 async def test_process_plus():
@@ -41,3 +41,34 @@ async def test_process_normal_passthrough():
     """Normal mode: kein LLM, Text unveraendert zurueck."""
     result = await process_text("Hallo Welt", ProcessMode.NORMAL)
     assert result == "Hallo Welt"
+
+
+def test_strip_meta_lines():
+    """🔊-TTS-Zeilen werden entfernt, normaler Text bleibt erhalten."""
+    text = "Sauberer Text\n🔊 Das hier ist eine Sprachausgabe-Zeile"
+    assert _strip_meta_lines(text) == "Sauberer Text"
+    # Reiner Text bleibt unveraendert (nur getrimmt)
+    assert _strip_meta_lines("  Nur Text  ") == "Nur Text"
+
+
+@pytest.mark.asyncio
+async def test_call_claude_cli_uses_system_prompt_and_isolated_settings():
+    """CLI-Aufruf nutzt --system-prompt + isolierte Settings, strippt Meta-Zeilen."""
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate = AsyncMock(return_value=(b"sauberer text", b""))
+
+    with patch(
+        "asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=mock_proc),
+    ) as mock_exec:
+        result = await _call_claude_cli("SYSPROMPT", "roher text", "sonnet")
+
+    assert result == "sauberer text"
+    args = mock_exec.call_args.args
+    assert "--system-prompt" in args
+    assert "SYSPROMPT" in args
+    assert "--setting-sources" in args
+    assert "" in args
+    assert "roher text" in args
+    assert "-p" in args


### PR DESCRIPTION
## Zwei Bugs behoben

### 1. Live-Modus „keine Verbindung zum Server", Neustart wirkungslos
**Ursache:** Die `/live`-Seite verriegelte sich dauerhaft (`stopped=true` bei `done`), reconnectete nie wieder; der Tray-Neustart bounct nur das Backend, nicht den toten Browser-Tab.
**Fix:**
- Seite reconnectet alle 3 s bis der Tab geschlossen wird (`pageClosing` statt `stopped`)
- Status „⏳ Warte auf Live-Session…" + neuer „🔄 Neu verbinden"-Button
- Tray: „Live-Modus starten/stoppen" + Neustart **mit Rückmeldung**
- Neuer idempotenter `POST /live/start`; Daemon-Logik in `_start_live`/`_stop_live`/`start_live()` aufgeteilt
- `/api/status` liefert zusätzlich `live`

### 2. Ungewollte 🔊-/Hinweis-Zeile am Diktat
**Ursache:** `claude -p` lud die globale `~/.claude/CLAUDE.md` (supertonic-🔊-Regel, „Korrekturen erklären") und hängte sie an den bereinigten Text.
**Fix:** `_call_claude_cli` → Transkript als `-p`, Anweisung via `--system-prompt`, `--setting-sources ""` (kein CLAUDE.md/Settings/Hooks/Auto-Memory), neutrales cwd, + `_strip_meta_lines`.

## Verifikation
- ✅ Live-Test mit sonnet → saubere Zeile, **kein 🔊, kein Meta-Kommentar**
- ✅ 3 neue Tests grün, **0 neue Failures** (5 rote Tests in `test_inject`/`test_transcribe` sind vorbestehend, per Stash auf HEAD bestätigt)
- 9 Dateien, +206/−60

🤖 Generated with [Claude Code](https://claude.com/claude-code)